### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/srinivasjst88/a487a287-224e-41aa-a009-0a0f7f070cd2/ed43f1d6-75ab-46c8-889e-12137394605d/_apis/work/boardbadge/f8425b64-61cf-41d7-bce6-b27365ad7d9f)](https://dev.azure.com/srinivasjst88/a487a287-224e-41aa-a009-0a0f7f070cd2/_boards/board/t/ed43f1d6-75ab-46c8-889e-12137394605d/Microsoft.RequirementCategory)
 
 Ansible Examples
 ----------------


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/srinivasjst88/a487a287-224e-41aa-a009-0a0f7f070cd2/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.